### PR TITLE
Include aiohttp dependency in the main project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psutil==5.9.5
 platformdirs==3.11.0
 aiofiles==23.2.1
 bigtree[pandas]==0.14.3
+aiohttp==3.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ psutil==5.9.5
 platformdirs==3.11.0
 aiofiles==23.2.1
 bigtree[pandas]==0.14.3
-aiohttp==3.9.3
+aiohttp==3.8.6


### PR DESCRIPTION
Hi Valerio,

I tried your project, and it seems very interesting to me. 
I noticed a small issue: Aiohttp dependency  which you use in synching.py is missing in the requirements file.
I know you included it in pyrclone, which you provided as a submodule, but in some cases (for example using virtualenv) could be a problem because pyrclone and robinhood are rightly decoupled.

I would like to contribute to the project and fix some bugs in my free time (which is never enough unfortunately :D) .

Ciao!